### PR TITLE
fix: correct Dtk6SettingsToolsMacros.cmake path

### DIFF
--- a/cmake/DtkTools/DtkToolsConfig.cmake.in
+++ b/cmake/DtkTools/DtkToolsConfig.cmake.in
@@ -7,7 +7,7 @@ if (EXISTS ${DTK_SETTINGS_TOOLS_EXECUTABLE})
     set(DTK_SETTINGS_TOOLS_FOUND TRUE)
 endif ()
 
-include("${CMAKE_CURRENT_LIST_DIR}/DtkSettingsToolsMacros.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Dtk6SettingsToolsMacros.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/DtkToolsTargets.cmake")
 
 get_target_property(DTK_XML2CPP Dtk@DTK_VERSION_MAJOR@::Xml2Cpp LOCATION)

--- a/cmake/DtkTools/DtkToolsConfig.cmake.in
+++ b/cmake/DtkTools/DtkToolsConfig.cmake.in
@@ -7,7 +7,7 @@ if (EXISTS ${DTK_SETTINGS_TOOLS_EXECUTABLE})
     set(DTK_SETTINGS_TOOLS_FOUND TRUE)
 endif ()
 
-include("${CMAKE_CURRENT_LIST_DIR}/Dtk6SettingsToolsMacros.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Dtk${DTK_VERSION_MAJOR}SettingsToolsMacros.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/DtkToolsTargets.cmake")
 
 get_target_property(DTK_XML2CPP Dtk@DTK_VERSION_MAJOR@::Xml2Cpp LOCATION)


### PR DESCRIPTION
修正 Dtk6SettingsToolsMacros.cmake 路径不正确的问题

（ps. 不确定这个修法对不对，安装路径下对应的文件名确实是 Dtk6SettingsToolsMacros，不过路径里本身也有 dtk6 所以如果改成文件名里不带 6 也说得通）