### PR TITLE
fix: add missing dependency for libdtk6core-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Description: Deepin Tool Kit Core Utilities
 
 Package: libdtk6core-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libdtk6core (= ${binary:Version})
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdtk6core (= ${binary:Version}), libdtkcommon-dev (>= 5.6.16)
 Description: Deepin Tool Kit Core Devel library
  DtkCore is base devel library of Deepin Qt/C++ applications.
  .


### PR DESCRIPTION
compared to libdtkcore-dev, libdtkcommon-dev is missing in Depends
when install libdtk6core-dev only, CMake cannot find Dtk6Config.cmake

Log: add libdtkcommon-dev (>= 5.6.16) in libdtk6core-dev Depends