### PR TITLE
chore: bump version to 6.0.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtk6core (6.0.28) unstable; urgency=medium
+
+  * 6.0.28
+
+ -- YeShanShan <yeshanshan@deepin.org>  Tue, 14 Jan 2025 19:17:45 +0800
+
 dtk6core (6.0.27) unstable; urgency=medium
 
   * 6.0.27


### PR DESCRIPTION
update changelog to 6.0.28