### PR TITLE
chore: bump version to 6.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtk6core (6.0.36) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkcore
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Mon, 19 May 2025 17:23:22 +0800
+
 dtk6core (6.0.35) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkcore


### PR DESCRIPTION
update changelog to 6.0.36