### PR TITLE
fix: add security hardening flags to build configuration

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,12 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 export DEB_CXXFLAGS_MAINT_APPEND = -Ofast
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)


### PR DESCRIPTION
1. Added security hardening compilation flags to debian/rules
2. Included DEB_BUILD_MAINT_OPTIONS with hardening=+all
3. Added warning flags (-Wall) for C/C++ compilation
4. Implemented secure linker flags (-Wl) for RELRO, immediate binding,
noexecstack
5. These changes improve binary security by enabling modern protection
mechanisms

fix: 在构建配置中添加安全加固标志

1. 在 debian/rules 中添加了安全加固编译标志
2. 包含带有 hardening=+all 的 DEB_BUILD_MAINT_OPTIONS
3. 为 C/C++ 编译添加了警告标志 (-Wall)
4. 实现了安全链接器标志 (-Wl) 用于 RELRO、立即绑定、noexecstack
5. 这些更改通过启用现代保护机制提高了二进制安全性
