### PR TITLE
fix: add libdbus-1-dev to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends:
  libuchardet-dev,
  libicu-dev,
  libdtkcommon-dev (>= 5.6.4),
- libdtk6log-dev
+ libdtk6log-dev,
+ libdbus-1-dev
 Standards-Version: 3.9.8
 
 Package: libdtk6core


### PR DESCRIPTION
Added libdbus-1-dev to the Build-Depends list in debian/control. This
dependency is required for proper compilation with DBus functionality,
which is used for inter-process communication in the DTK framework. The
package was likely missing from initial dependency list causing build
failures on some systems.

fix: 在构建依赖中添加 libdbus-1-dev

在 debian/control 的 Build-Depends 列表中添加了 libdbus-1-dev。这个依赖
项是正确编译 DBus 功能所必需的，DBus 在 DTK 框架中用于进程间通信。该软件
包最初可能被遗漏，导致在某些系统上构建失败。
