### PR TITLE
chore: bump version to 6.0.40

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dtk6core (6.0.40) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkcore
+  * chore(CI): add debian check workflow
+  * Fix configuration for Packit 1.0.0
+  * sync: from linuxdeepin/dtkcore
+  * fix: add libdbus-1-dev to build dependencies
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 10 Jul 2025 18:42:04 +0800
+
 dtk6core (6.0.39) unstable; urgency=medium
 
   * Release 6.0.39


### PR DESCRIPTION
update changelog to 6.0.40